### PR TITLE
Add option for key value delimiter

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -271,7 +271,12 @@ func convert(val string, retval reflect.Value, options multiTag) error {
 
 		retval.Set(reflect.Append(retval, elemval))
 	case reflect.Map:
-		parts := strings.SplitN(val, ":", 2)
+		keyValueDelimiter := options.Get("key-value-delimiter")
+		if keyValueDelimiter == "" {
+			keyValueDelimiter = ":"
+		}
+
+		parts := strings.SplitN(val, keyValueDelimiter, 2)
 
 		key := parts[0]
 		var value string

--- a/convert_test.go
+++ b/convert_test.go
@@ -157,3 +157,22 @@ func TestConvertToStringInvalidUintBase(t *testing.T) {
 
 	assertError(t, err, ErrMarshal, "strconv.ParseInt: parsing \"no\": invalid syntax")
 }
+
+func TestConvertToMapWithDelimiter(t *testing.T) {
+	var opts = struct {
+		StringStringMap map[string]string `long:"string-string-map" key-value-delimiter:"="`
+	}{}
+
+	p := NewNamedParser("test", Default)
+	grp, _ := p.AddGroup("test group", "", &opts)
+	o := grp.Options()[0]
+
+	err := convert("key=value", o.value, o.tag)
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+		return
+	}
+
+	assertString(t, opts.StringStringMap["key"], "value")
+}


### PR DESCRIPTION
## Description

Currently, a map flag only allows `:` as the delimiter between key and value, e.g. `-f key:value`. This PR allows customisation of the delimiter so users can choose a delimiter that is better suited for their use case. For example, it's more natural to use `-e key=value` for a map flag of environment variables.

Users can specify the delimiter via tag options. The default delimiter is `:`.

```
type MyFlag struct {
    MyMap map[string]string `short:"f" key-value-delimiter:"="`
}
```